### PR TITLE
[REVIEW] Integrate processor to complete request lifecycle

### DIFF
--- a/lib/alephant/publisher/request.rb
+++ b/lib/alephant/publisher/request.rb
@@ -17,6 +17,8 @@ module Alephant
       class Request
         attr_reader :processor, :data_mapper_factory
 
+        DEFAULT_CONTENT_TYPE = { "Content-Type" => "text/html" }
+
         def initialize(processor, data_mapper_factory)
           @processor           = processor
           @data_mapper_factory = data_mapper_factory
@@ -24,19 +26,37 @@ module Alephant
 
         def call(env)
           req      = Rack::Request.new(env)
-          response = Rack::Response.new("<h1>Not Found</h1>", 404, { "Content-Type" => "text/html" })
+          response = Rack::Response.new("<h1>Not Found</h1>", 404, DEFAULT_CONTENT_TYPE)
 
           case req.path_info
           when /status$/
             response = status
           when /component\/(?<id>[^\/]+)$/
-            component_id = $~['id']
-            response     = Rack::Response.new("<p>#{component_id}</p>", 200, { "Content-Type" => "text/html" })
+            response = Rack::Response.new(
+              template_data($~['id'], req.params),
+              200,
+              DEFAULT_CONTENT_TYPE
+            )
           end
 
           response.finish
         rescue Exception => e
-          Rack::Response.new("<h1>An exception occured: #{e.message}</h1>", 500, { 'Content-Type' => 'text/html' })
+          Rack::Response.new("<h1>An exception occured: #{e.message}</h1>", 500, DEFAULT_CONTENT_TYPE)
+        end
+
+        protected
+
+        def render_component(component_id, params)
+          Rack::Response.new(
+            template_data(component_id, params),
+            200,
+            { "Content-Type" => "text/html" }
+          )
+        end
+
+        def template_data(component_id, params)
+          mapper = data_mapper_factory.create(component_id, params)
+          processor.consume(mapper.data, component_id)
         end
 
       end

--- a/lib/alephant/publisher/request/data_mapper.rb
+++ b/lib/alephant/publisher/request/data_mapper.rb
@@ -19,7 +19,7 @@ module Alephant
 
         def get(uri)
           response = connection.get(uri)
-          raise InvalidApiResponse unless response.status == 200
+          raise InvalidApiResponse, "Status: #{response.status}" unless response.status == 200
           JSON::parse(response.body, :symbolize_names => true)
         rescue Faraday::ConnectionFailed
           raise ConnectionFailed

--- a/lib/alephant/publisher/request/data_mapper.rb
+++ b/lib/alephant/publisher/request/data_mapper.rb
@@ -23,8 +23,10 @@ module Alephant
           JSON::parse(response.body, :symbolize_names => true)
         rescue Faraday::ConnectionFailed
           raise ConnectionFailed
-        rescue Error, JSON::ParserError
-          raise InvalidApiResponse
+        rescue JSON::ParserError
+          raise InvalidApiResponse, "JSON parsing error: #{response.body}"
+        rescue StandardError => e
+          raise ApiError, e.message
         end
 
       end

--- a/lib/alephant/publisher/request/data_mapper_factory.rb
+++ b/lib/alephant/publisher/request/data_mapper_factory.rb
@@ -16,9 +16,9 @@ module Alephant
           klass = mapper_class_for(component_id)
           klass.new(connection, context)
         rescue LoadError
-          raise InvalidComponentName, component_id
+          raise InvalidComponentName, "Invalid component name: #{component_id}"
         rescue NameError
-          raise InvalidComponentClassName, klass
+          raise InvalidComponentClassName, "Invalid class name #{klass}"
         rescue
           raise InvalidComponent, "Name: #{component_id}, Class: #{klass}"
         end
@@ -26,7 +26,7 @@ module Alephant
         protected
 
         def base_path_for(component_id)
-          "#{base_path}/components/#{component_id}/mapper"
+          "#{base_path}/#{component_id}/mapper"
         end
 
         def camalize(snake_case)

--- a/lib/alephant/publisher/request/error.rb
+++ b/lib/alephant/publisher/request/error.rb
@@ -2,9 +2,10 @@ module Alephant
   module Publisher
     module Request
       class Error < StandardError; end
-      class InvalidApiResponse < Error; end
       class ConnectionFailed < Error; end
       class InvalidComponent < Error; end
+      class ApiError < Error; end
+      class InvalidApiResponse < ApiError; end
       class InvalidComponentBasePath < InvalidComponent; end
       class InvalidComponentName < InvalidComponent; end
       class InvalidComponentClassName < InvalidComponent; end

--- a/spec/data_mapper_factory_spec.rb
+++ b/spec/data_mapper_factory_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Alephant::Publisher::Request::DataMapperFactory do
   let (:connection) { instance_double(Faraday::Connection) }
-  let (:base_path) { File.join(File.dirname(__FILE__), 'fixtures') }
+  let (:base_path) { File.join(File.dirname(__FILE__), 'fixtures', 'components') }
 
   subject { described_class.new(connection, base_path) }
 

--- a/spec/integration/rack_server_spec.rb
+++ b/spec/integration/rack_server_spec.rb
@@ -2,20 +2,61 @@ require_relative "./spec_helper"
 
 describe Alephant::Publisher::Request do
   include Rack::Test::Methods
-  let (:processor) { instance_double(Alephant::Publisher::Request::Processor) }
-  let (:data_mapper_factory) { instance_double(Alephant::Publisher::Request::DataMapperFactory) }
-  let (:app) { subject.create(processor, data_mapper_factory) }
+  let (:response) { instance_double(Faraday::Response, :status => 200, :body => nil) }
+  let (:base_path) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'components') }
+  let (:processor) { Alephant::Publisher::Request::Processor.new(base_path) }
+  let (:connection) { instance_double(Faraday::Connection, :get => response) }
+  let (:data_mapper_factory) { Alephant::Publisher::Request::DataMapperFactory.new(connection, base_path) }
+  let (:app) { subject.create(processor, data_mapper_factory, { :debug => true }) }
 
-  describe "GET /component/{param}" do
-
-    context "with a valid parameter" do
-
-      it "returns HTML" do
-        get "/component/foo"
-        expect(last_response).to be_ok
-        expect(last_response.body).to eq "<p>foo</p>"
-      end
+  describe "status endpoint (/status)" do
+    before(:each) do
+      get "/status"
     end
 
+    context "status code" do
+      specify { expect(last_response.status).to eq 204 }
+    end
+  end
+
+  describe "component endpoint (/component/{component_id}?foo=bar)" do
+    let (:component_id) { "foo" }
+
+    context "content" do
+
+      context "with a valid component id" do
+        let (:api_response) { "{\"content\":\"#{component_id}\"}" }
+        before(:each) do
+          allow(response).to receive(:body).and_return(api_response)
+          get "/component/#{component_id}"
+        end
+
+        specify { expect(last_response.body.chomp).to eq component_id }
+      end
+
+    end
+
+    context "status code" do
+
+      context "with an invalid component id" do
+        let (:component_id) { "foo_invalid" }
+        before(:each) do
+          get "/component/#{component_id}"
+        end
+
+        specify { expect(last_response.status).to eq 404 }
+      end
+
+      context "with an invalid API endpoint" do
+        let (:expected_exception) { Alephant::Publisher::Request::InvalidApiResponse }
+        before(:each) do
+          allow(connection).to receive(:get).and_raise expected_exception
+          get "/component/#{component_id}"
+        end
+
+        specify { expect(last_response.status).to eq 502 }
+      end
+
+    end
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -3,11 +3,6 @@ require "spec_helper"
 describe Alephant::Publisher::Request do
   let (:processor) { instance_double(Alephant::Publisher::Request::Processor, :consume => nil) }
   let (:data_mapper_factory) { instance_double(Alephant::Publisher::Request::DataMapperFactory, :create => nil) }
-  let (:options) {
-    {
-      :foo => :bar
-    }
-  }
 
   describe ".create" do
     context "Using valid params" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'aws-sdk'
 require 'faraday'
 require 'alephant/renderer'
 require 'alephant/publisher/request'
+require 'alephant/publisher/request/error'
 require 'alephant/publisher/request/data_mapper'
 require 'alephant/publisher/request/data_mapper_factory'
 


### PR DESCRIPTION
![lost](https://cloud.githubusercontent.com/assets/527874/4602014/dec854b4-5122-11e4-8954-6e109955692e.gif)
### Problem

Currently the `Alephant::Publisher::Request` class was returning the component name, we want it actually use the data mapper based on the component id and return a rendered template.
### Solution

Use the passed in data mapper factory to create a data mapper, and handle exceptions thrown accordingly for meaningful HTTP response codes. The rack integration tests have also been updated to reflect these new changes.
