### PR TITLE
[READY] Changes status endpoint to return 200

### DIFF
--- a/lib/alephant/publisher/request.rb
+++ b/lib/alephant/publisher/request.rb
@@ -31,7 +31,7 @@ module Alephant
 
           case req.path_info
           when /status$/
-            response = Rack::Response.new('', 204, DEFAULT_CONTENT_TYPE)
+            response = Rack::Response.new('ok', 200, DEFAULT_CONTENT_TYPE)
           when /component\/(?<id>[^\/]+)$/
             response = Rack::Response.new(
               template_data($~['id'], req.params),

--- a/spec/integration/rack_server_spec.rb
+++ b/spec/integration/rack_server_spec.rb
@@ -15,7 +15,7 @@ describe Alephant::Publisher::Request do
     end
 
     context "status code" do
-      specify { expect(last_response.status).to eq 204 }
+      specify { expect(last_response.status).to eq 200 }
     end
   end
 


### PR DESCRIPTION
### Problem

The status endpoint returns 204 and for certain services this isn't considered as 'ok', we should change this to 200 to be safe.
