### PR TITLE
[READY] Updates metric name to correct one

### DIFF
--- a/lib/alephant/publisher/request/connection.rb
+++ b/lib/alephant/publisher/request/connection.rb
@@ -16,16 +16,16 @@ module Alephant
         def get(uri)
           JSON::parse(request(uri).body, :symbolize_names => true)
         rescue Faraday::ConnectionFailed => e
-          log_error_with_metric(e, 'DataMapper#request', uri, "PublisherRequestDataMapperConnectionFailed")
+          log_error_with_metric(e, 'Connection#request', uri, "PublisherRequestConnectionConnectionFailed")
           raise ConnectionFailed
         rescue InvalidApiStatus => e
-          log_error_with_metric(e, 'DataMapper#request', uri, "PublisherRequestDataMapperInvalidStatus#{e.status}")
+          log_error_with_metric(e, 'Connection#request', uri, "PublisherRequestConnectionInvalidStatus#{e.status}")
           raise e
         rescue JSON::ParserError => e
-          log_error_with_metric(e, 'DataMapper#get', uri, "PublisherRequestDataMapperInvalidApiResponse")
+          log_error_with_metric(e, 'Connection#get', uri, "PublisherRequestConnectionInvalidApiResponse")
           raise InvalidApiResponse, "JSON parsing error: #{response.body}"
         rescue StandardError => e
-          log_error_with_metric(e, 'DataMapper#get', uri, "PublisherRequestDataMapperApiError")
+          log_error_with_metric(e, 'Connection#get', uri, "PublisherRequestConnectionApiError")
           raise ApiError, e.message
         end
 
@@ -33,13 +33,13 @@ module Alephant
 
         def request(uri)
           before = Time.new
-          logger.info "Publisher::Request::DataMapper#request: uri: #{uri}"
+          logger.info "Publisher::Request::Connection#request: uri: #{uri}"
 
           driver.get(uri).tap do |response|
             response_time = Time.new - before
-            logger.metric(:name => "PublisherRequestDataMapperRequestHTTPTime", :unit => 'Seconds', :value => response_time)
-            logger.info "Publisher::Request::DataMapper#request: API response time: #{response_time}"
-            logger.info "Publisher::Request::DataMapper#request: status returned: #{response.status} for #{uri}"
+            logger.metric(:name => "PublisherRequestConnectionRequestHTTPTime", :unit => 'Seconds', :value => response_time)
+            logger.info "Publisher::Request::Connection#request: API response time: #{response_time}"
+            logger.info "Publisher::Request::Connection#request: status returned: #{response.status} for #{uri}"
             raise InvalidApiStatus, response.status unless response.status == 200
           end
         end


### PR DESCRIPTION
### Problem

After rebasing the latest changes into the logging branch, the logging was moved to the connection class but the names in the messages didn't change.

### Solution

Update them.